### PR TITLE
Allow toBeRdfIsomorphic to take datasets

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ import "jest-rdf";
 #### toBeRdfIsomorphic
 
 Check if two RDF graphs are [isomorphic](https://www.w3.org/TR/rdf11-concepts/#graph-isomorphism).
-An RDF graph is represented as an array of quads where the order of quads is not important.
+An RDF graph is represented as an iterable of quads where the order of quads is not important.
 
 ```js
 const g1 = [
@@ -58,6 +58,7 @@ const g2 = [
   quad(blankNode('b2'), namedNode('p1'), namedNode('o1'), namedNode('g1')),
 ];
 expect(g1).toBeRdfIsomorphic(g2);
+expect(dataset(g1)).toBeRdfIsomorphic(dataset(g2));
 ```
 
 #### toEqualRdfQuad

--- a/index.ts
+++ b/index.ts
@@ -9,7 +9,7 @@ declare global {
       toBeRdfDatasetContaining: (...actual: RDF.BaseQuad[]) => R;
       toBeRdfDatasetMatching: (match: IQuadTerms<RDF.BaseQuad>, matches?: number) => R;
       toBeRdfDatasetOfSize: (size: number) => R;
-      toBeRdfIsomorphic: (actual: RDF.BaseQuad[]) => R;
+      toBeRdfIsomorphic: (actual: Iterable<RDF.BaseQuad>) => R;
       toEqualRdfQuad: (actual: RDF.BaseQuad) => R;
       toEqualRdfQuadArray: (actual: RDF.BaseQuad[]) => R;
       toEqualRdfTerm: (actual: RDF.Term) => R;

--- a/lib/matchers/toBeRdfIsomorphic.ts
+++ b/lib/matchers/toBeRdfIsomorphic.ts
@@ -7,16 +7,19 @@ function quadArrayToString<Q extends RDF.BaseQuad = RDF.Quad>(quadArray: Q[]): s
 }
 
 export default {
-  toBeRdfIsomorphic<Q extends RDF.BaseQuad = RDF.Quad>(received: Q[], actual: Q[]) {
-    if (!isomorphic(received, actual)) {
+  toBeRdfIsomorphic<Q extends RDF.BaseQuad = RDF.Quad>(received: Iterable<Q>, actual: Iterable<Q>) {
+    const receivedArray = [...received];
+    const actualArray = [...actual];
+
+    if (!isomorphic(receivedArray, actualArray)) {
       return {
         message: () => `expected two graphs to be isomorphic.
 
   Expected:
-${quadArrayToString(actual)}
+${quadArrayToString(actualArray)}
 
   Actual:
-${quadArrayToString(received)}
+${quadArrayToString(receivedArray)}
 `,
         pass: false,
       };
@@ -26,10 +29,10 @@ ${quadArrayToString(received)}
       message: () => `expected two graphs not to be isomorphic.
 
   Expected:
-${quadArrayToString(actual)}
+${quadArrayToString(actualArray)}
 
   Actual:
-${quadArrayToString(received)}
+${quadArrayToString(receivedArray)}
 `,
       pass: true,
     };

--- a/test/matchers/toBeRdfIsomorphic-test.ts
+++ b/test/matchers/toBeRdfIsomorphic-test.ts
@@ -1,4 +1,5 @@
 import {blankNode, namedNode, quad} from "@rdfjs/data-model";
+import datasetFactory = require('rdf-dataset-indexed');
 import * as RDF from "rdf-js";
 import "../../index";
 
@@ -127,6 +128,48 @@ describe('#toBeRdfIsomorphic', () => {
         namedNode('g1'),
       ),
     ]);
+  });
+
+  it('should work with iterables', () => {
+    return expect(datasetFactory([
+      quad(
+        blankNode('s1a'),
+        namedNode('p1'),
+        namedNode('o1'),
+        namedNode('g1'),
+      ),
+      quad(
+        namedNode('s2'),
+        namedNode('p2'),
+        namedNode('o2'),
+        namedNode('g2'),
+      ),
+      quad(
+        namedNode('s3'),
+        namedNode('p3'),
+        namedNode('o3'),
+        namedNode('g3'),
+      ),
+    ])).toBeRdfIsomorphic(datasetFactory([
+      quad(
+        blankNode('s1b'),
+        namedNode('p1'),
+        namedNode('o1'),
+        namedNode('g1'),
+      ),
+      quad(
+        namedNode('s2'),
+        namedNode('p2'),
+        namedNode('o2'),
+        namedNode('g2'),
+      ),
+      quad(
+        namedNode('s3'),
+        namedNode('p3'),
+        namedNode('o3'),
+        namedNode('g3'),
+      ),
+    ]));
   });
 
   it('should not fail for equal quad arrays', () => {


### PR DESCRIPTION
Expands toBeRdfIsomorphic to take iterables rather than just arrays, so it can be used for datasets etc.