### PR TITLE
Export matchers explicitly

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -22,6 +22,10 @@ const jestExpect = (<any> global).expect;
 
 if (jestExpect) {
   jestExpect.extend(matchers);
-} else {
-  throw new Error('Jest was not installed.');
 }
+
+export const enforceJestGlobal = () => {
+  if (!jestExpect) {
+    throw new Error("Jest was not installed.");
+  }
+};

--- a/index.ts
+++ b/index.ts
@@ -29,3 +29,4 @@ export const enforceJestGlobal = () => {
     throw new Error("Jest was not installed.");
   }
 };
+export { matchers };


### PR DESCRIPTION
This change makes it possible to use this library with `jest` globals injection disabled. It no longer systematically throws if `jest` globals cannot be found on import, and export matchers so that the `expect` object may be extended by projects using explicit exports over globals injection.

If the change of the default behaviour on import (no longer throwing if jest globals aren't found) isn't acceptable, I can update this to use an environment variable instead, so that the new behavior would be opt-in.