### PR TITLE
Use `@rdfjs/types` for RDF types instead of `rdf-js`

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,4 +1,4 @@
-import * as RDF from "rdf-js";
+import * as RDF from "@rdfjs/types";
 import matchers from './lib/matchers';
 import { IQuadTerms } from './lib/matchers/toBeRdfDatasetMatching';
 


### PR DESCRIPTION
Using `jest-rdf` in a project that does not include `rdf-js` itself causes TypeScript compiler errors:
```
node_modules/jest-rdf/index.d.ts:1:22 - error TS2307: Cannot find module 'rdf-js' or its corresponding type declarations.

1 import * as RDF from "rdf-js";
                       ~~~~~~~~
```
This should fix that.